### PR TITLE
ci: configura checagem de linting e formatação de código

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,21 @@
+name: "Roda Cargo Clippy e Rust Format"
+
+on:
+    workflow_call: 
+
+jobs:
+    check_linting:
+        name: "ensures code follows standard code style guide"
+        runs-on: "ubuntu-latest"
+        steps:
+            - uses: actions/checkout@v4
+            - run: rustup update
+            - run: cargo clippy --all-targets --all-features -- -D warnings
+
+    check_code_fmt:
+        name: "ensures code is formatted"
+        runs-on: "ubuntu-latest"
+        steps:
+            - uses: actions/checkout@v4
+            - run: rustup update
+            - run: cargo fmt --all -- --check

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,0 +1,9 @@
+name: "Projetário's Pipeline"
+
+on:
+    push: 
+    pull_request: 
+
+jobs:
+    linting_and_format:
+        uses: "./.github/workflows/linting.yaml"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+channel = "1.86"
+components = [
+  "rustc",
+  "rustfmt",
+  "rust-std",
+  "cargo",
+  "clippy",
+  "rust-analyzer",
+]


### PR DESCRIPTION
# Adicionado
- `rust-toolchain.toml` com componentes padrão para o desenvolvimento do projeto
- workflow `linting` para checar a formatação com `cargo fmt` e linting com `cargo clippy`