### PR TITLE
chore: configura o Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# build directories
+target/
+**/build/
+**/dist/
+**/bundle/
+**/hot
+node_modules/
+
+# env files
+.env
+.env.*
+
+# application directories
+storage/
+
+# IDE and config directories
+.vscode/
+.github/
+
+# others
+readme.md
+Dockerfile

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -8,10 +8,10 @@ jobs:
         name: "ensures code follows standard code style guide"
         runs-on: "ubuntu-latest"
         steps:
-            - name: "cache incremental build artifacts for speeding up clippy check"
-              uses: Swatinem/rust-cache@v2
             - uses: actions/checkout@v4
             - run: rustup update
+            - name: "cache incremental build artifacts for speeding up clippy check"
+              uses: Swatinem/rust-cache@v2
             - run: cargo clippy --all-targets --all-features -- -D warnings
 
     check_code_fmt:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -8,6 +8,8 @@ jobs:
         name: "ensures code follows standard code style guide"
         runs-on: "ubuntu-latest"
         steps:
+            - name: "cache incremental build artifacts for speeding up clippy check"
+              uses: Swatinem/rust-cache@v2
             - uses: actions/checkout@v4
             - run: rustup update
             - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1962,13 +1962,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.108"
+name = "openssl-src"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2219,6 +2229,7 @@ dependencies = [
  "inertia-rust",
  "inertia-sessions",
  "log",
+ "openssl",
  "pretty_assertions",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ serde_json = "1.0.140"
 rand = "0.9.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 pretty_assertions = "1.4.1"
-rstest = "0.25.0"
 dotenvy = "0.15.7"
 env_logger = "0.11.8"
 futures-util = "0.3.31"
 thiserror = "2.0.12"
+rstest = "0.25.0"
 
 [dependencies]
 actix-files.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "projetario"
 version.workspace = true
 edition.workspace = true
 
+[features]
+dockerimgb = []
+
 [workspace]
 members = ["config", "sessions"]
 package.version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ sqlx = { version = "0.8.5", features = ["runtime-tokio", "tls-rustls-ring-native
 thiserror.workspace = true
 validator = { version = "0.20", features = ["derive"] }
 uuid = { version = "1.17.0", features = ["v4"] }
+openssl = { version = "0.10.73", features = ["vendored"]}
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ COPY Cargo.lock Cargo.toml rust-toolchain.toml ./
 COPY config/ ./config
 COPY sessions/ ./sessions/
 
+# É necessário para manter as dependências em cache. O Cargo não possui um meio de compilar
+# somente as dependências para evitar recompilar tudo a cada alteração no código fonte,
+# e esta é uma gambiarra pra atingir algo próximo disso.
+#
+# Veja: https://github.com/rust-lang/cargo/issues/2644#issuecomment-2335499312
 RUN \
     mkdir -v src && \
     echo 'fn main() {}' > src/main.rs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+#####################################################################################################
+FROM rust:1.86 AS build-backend
+
+WORKDIR /app
+
+# Pré-compila as dependências e mantém elas em cache pra diminuir o tempo de compilação
+COPY Cargo.lock Cargo.toml rust-toolchain.toml ./
+COPY config/ ./config
+COPY sessions/ ./sessions/
+
+RUN \
+    mkdir -v src && \
+    echo 'fn main() {}' > src/main.rs && \
+    cargo build --release && \
+    rm -Rvf src
+
+# Copia o resto da aplicação e compila em uma segunda camada, evitando a invalidação do cache
+# das dependências acima
+COPY . .
+RUN cargo build --release --locked --features=dockerimgb
+
+#####################################################################################################
+FROM node:22-slim AS build-frontend
+
+WORKDIR /app
+
+# Instala as dependências em outra camada para mantê-las em cache
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Builda o front-end em outra camada para evitar invalidar o cache das dependências à toa
+COPY www/ ./www/
+COPY public/ ./public/
+COPY tsconfig.json vite.config.ts ./
+RUN npm run build
+
+#####################################################################################################
+FROM ubuntu:22.10 AS final
+
+WORKDIR /app
+
+COPY --from=build-backend /app/target/release/projetario .
+COPY --from=build-frontend /app/public/ ./public/
+COPY --from=build-frontend /app/dist/ ./dist/
+COPY www/root.hbs ./www/root.hbs
+
+EXPOSE 80
+EXPOSE 443
+
+# Cria um usuário somente para rodar o sistema, de modo que ele não tenha privilégios de super usuário.
+# Ele ainda precisa ter permissão pra manusear os arquivos dentro de /app, no entanto.
+RUN useradd -m projetario
+RUN chown -R projetario:projetario /app
+RUN chmod 755 /app
+
+USER projetario
+
+ENTRYPOINT [ "./projetario" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ COPY --from=build-frontend /app/dist/ ./dist/
 COPY www/root.hbs ./www/root.hbs
 
 EXPOSE 80
-EXPOSE 443
 
 # Cria um usuário somente para rodar o sistema, de modo que ele não tenha privilégios de super usuário.
 # Ele ainda precisa ter permissão pra manusear os arquivos dentro de /app, no entanto.

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,3 +9,10 @@ services:
       POSTGRES_USER: ${MAIN_DB_USER}
       POSTGRES_PASSWORD: ${MAIN_DB_PASSWORD}
       POSTGRES_DB: ${MAIN_DB_NAME}
+  app:
+    container_name: projetario-app
+    image: projetario/app:0.1.0
+    ports:
+      - 3000:80
+    volumes:
+      - .env:/app/.env

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,10 @@ Para rodar, será necessário ter o [Docker](https://docs.docker.com/get-started
 Feito isso, siga o passo-a-passo adiante:
 1. Clone este repositório com o comando `git clone git@github.com:Projetario-UTFPR/projetario.git projetario`
 2. Navegue para o diretório do repositório: `cd projetario`
-3. Gere a imagem Docker: `docker build -t projetario/app:0.1.0 .` (observe que o ponto
+3. Adicione as variáveis de ambiente: `cp .env.sample .env`
+4. Gere a imagem Docker: `docker build -t projetario/app:0.1.0 .` (observe que o ponto
 é necessário)
-4. Levante os serviços com o comando `docker compose up -d`
+5. Levante os serviços com o comando `docker compose up -d`
 
 Feito isso, basta acessar o sistema através da URL http://localhost:3000.
 
@@ -28,4 +29,3 @@ Para contribuir com o desenvolvimento do Projetário UTFPR, leia o
 
 ## Licença
 O Projetário UTFPR é open-source e pode ser distribuído sob a [licença MIT](./LICENSE).
-

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ Feito isso, siga o passo-a-passo adiante:
 
 Feito isso, basta acessar o sistema através da URL http://localhost:3000.
 
+Digite `docker compose stop` para parar os containers ou `docker compose down` para destruí-los.
+
 ## Contribuindo
 Para contribuir com o desenvolvimento do Projetário UTFPR, leia o
 [Guia de Contribuição](.github/contribuindo.md).

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,19 @@ Todos os requisitos funcionais e não-funcionais, os quais guiam o desenvolvimen
 deste sistema, estão disponíveis no documento de
 [Objetivos e Requisitos](.github/requisitos.md).
 
+## Rodando Localmente
+Para rodar, será necessário ter o [Docker](https://docs.docker.com/get-started/get-docker/)
+à disposição, bem como o [GIT](https://git-scm.com/book/pt-br/v2/Come%C3%A7ando-Instalando-o-Git).
+
+Feito isso, siga o passo-a-passo adiante:
+1. Clone este repositório com o comando `git clone git@github.com:Projetario-UTFPR/projetario.git projetario`
+2. Navegue para o diretório do repositório: `cd projetario`
+3. Gere a imagem Docker: `docker build -t projetario/app:0.1.0 .` (observe que o ponto
+é necessário)
+4. Levante os serviços com o comando `docker compose up -d`
+
+Feito isso, basta acessar o sistema através da URL http://localhost:3000.
+
 ## Contribuindo
 Para contribuir com o desenvolvimento do Projetário UTFPR, leia o
 [Guia de Contribuição](.github/contribuindo.md).

--- a/sessions/Cargo.toml
+++ b/sessions/Cargo.toml
@@ -14,6 +14,8 @@ rand = { workspace = true }
 anyhow = {workspace = true }
 tokio ={ workspace = true }
 chrono ={ workspace = true }
-rstest = { workspace = true }
 dotenvy = { workspace = true }
 futures-util = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,17 @@ async fn main() -> anyhow::Result<()> {
     let inertia = Data::new(get_inertia(vite).await?);
     let inertia_data = inertia.clone();
 
-    let port = if is_production_env { 80 } else { 3000 };
-    let host = if is_production_env {
+    // Se estiver sendo compilado em uma imagem Docker, é necessário que escute na porta padrão
+    // no IP padrão, de modo que seja possível levantá-lo como um container docker e fazer o bind
+    // dessa porta em outra porta (como está sendo feito no arquivo `compose.yaml`.)
+    #[cfg(feature = "dockerimgb")]
+    let must_listen_to_public_port = true;
+    #[cfg(not(feature = "dockerimgb"))]
+    let must_listen_to_public_port = is_production_env;
+
+    let port = if must_listen_to_public_port { 80 } else { 3000 };
+
+    let host = if must_listen_to_public_port {
         "0.0.0.0"
     } else {
         "127.0.0.1"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,22 @@
 pub mod erros;
 pub mod sqlx;
+
+pub fn resolve_uri<'b>(is_production_env: bool) -> (&'b str, u16) {
+    // Se estiver sendo compilado em uma imagem Docker, é necessário que escute na porta padrão
+    // no IP padrão, de modo que seja possível levantá-lo como um container docker e fazer o bind
+    // dessa porta em outra porta (como está sendo feito no arquivo `compose.yaml`.)
+    #[cfg(feature = "dockerimgb")]
+    let must_listen_to_public_port = true;
+    #[cfg(not(feature = "dockerimgb"))]
+    let must_listen_to_public_port = is_production_env;
+
+    let port = if must_listen_to_public_port { 80 } else { 3000 };
+
+    let host = if must_listen_to_public_port {
+        "0.0.0.0"
+    } else {
+        "127.0.0.1"
+    };
+
+    (host, port)
+}


### PR DESCRIPTION
Esse PR adiciona o Dockerfile e instruções de como rodar a aplicação como containers Docker.

Além disso, também modifica o workflow de linting de modo a armazenar um cache das crates para acelerar a compilação e checagem do Clippy.