### PR TITLE
fix: erro de assets

### DIFF
--- a/dominio/src/vagas/servicos/criar_vaga.rs
+++ b/dominio/src/vagas/servicos/criar_vaga.rs
@@ -272,7 +272,6 @@ mod test {
             })
             .await;
 
-        dbg!(&resultado);
         assert_eq!(deveria_permitir, resultado.is_ok());
     }
 

--- a/src/infra/http/routers/web.rs
+++ b/src/infra/http/routers/web.rs
@@ -10,6 +10,7 @@ pub struct WebRouter;
 impl RouterRegistrable for WebRouter {
     fn register(cfg: &mut actix_web::web::ServiceConfig) {
         cfg.inertia_route("/", "index")
+            .inertia_route("/dev/hello/world", "hello-world") // rota usada nos testes
             .configure(ControllerAutenticacao::register)
             .configure(ProfessoresControllersGroup::register)
             .configure(AcoesControllersGroup::register);

--- a/src/infra/http/routers/web.rs
+++ b/src/infra/http/routers/web.rs
@@ -1,3 +1,5 @@
+use inertia_rust::InertiaService;
+
 use crate::infra::http::RouterRegistrable;
 use crate::infra::http::controllers::acoes::AcoesControllersGroup;
 use crate::infra::http::controllers::autenticacao::ControllerAutenticacao;
@@ -7,7 +9,8 @@ pub struct WebRouter;
 
 impl RouterRegistrable for WebRouter {
     fn register(cfg: &mut actix_web::web::ServiceConfig) {
-        cfg.configure(ControllerAutenticacao::register)
+        cfg.inertia_route("/", "index")
+            .configure(ControllerAutenticacao::register)
             .configure(ProfessoresControllersGroup::register)
             .configure(AcoesControllersGroup::register);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,6 +28,7 @@ pub fn get_server() -> App<
     let storage = FileSessionStore::default();
 
     App::new()
+        .wrap(NormalizePath::trim())
         .service(actix_files::Files::new("/bundle/", "./public/bundle/").prefer_utf8(true))
         .service(actix_files::Files::new("/tiny-mce/", "./public/tiny-mce/").prefer_utf8(true))
         .route(
@@ -50,7 +51,6 @@ pub fn get_server() -> App<
                         .cookie_name(app_config.sessions_cookie_name.to_string())
                         .build(),
                 )
-                .wrap(NormalizePath::trim())
                 .configure(WebRouter::register)
                 // serviço de fallback de arquivos o ideal é manter tudo fora desse escopo, mas se ainda não tiver
                 // sido montado, esse aqui garante que vai ser entregue mesmo que sofra modificações decorrentes

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,10 @@
 use actix_session::SessionMiddleware;
-use actix_web::App;
-use actix_web::body::{BoxBody, EitherBody};
+use actix_web::body::BoxBody;
 use actix_web::cookie::{Key, SameSite};
 use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::middleware::NormalizePath;
+use actix_web::{App, web};
 use config::app::{AppConfig, RustEnv};
-use inertia_rust::InertiaService;
 use inertia_sessions::file_session::FileSessionStore;
 use inertia_sessions::middlewares::garbage_collector::GarbageCollectorMiddleware;
 use inertia_sessions::middlewares::reflash_temporary_session::ReflashTemporarySessionMiddleware;
@@ -19,7 +18,7 @@ pub fn get_server() -> App<
     impl ServiceFactory<
         ServiceRequest,
         Config = (),
-        Response = ServiceResponse<EitherBody<BoxBody>>,
+        Response = ServiceResponse<BoxBody>,
         Error = actix_web::Error,
         InitError = (),
     >,
@@ -29,22 +28,33 @@ pub fn get_server() -> App<
     let storage = FileSessionStore::default();
 
     App::new()
-        .wrap(GarbageCollectorMiddleware)
-        .wrap(get_inertia_middleware())
-        .wrap(ReflashTemporarySessionMiddleware)
-        .wrap(MiddlewareUsuarioDaRequisicao)
-        .wrap(
-            SessionMiddleware::builder(storage, key)
-                .cookie_domain(None)
-                .cookie_http_only(true)
-                .cookie_same_site(SameSite::Lax)
-                .cookie_secure(app_config.environment == RustEnv::Production)
-                .cookie_name(app_config.sessions_cookie_name.to_string())
-                .build(),
+        .service(actix_files::Files::new("/bundle/", "./public/bundle/").prefer_utf8(true))
+        .service(actix_files::Files::new("/tiny-mce/", "./public/tiny-mce/").prefer_utf8(true))
+        .route(
+            "/favicon.ico",
+            web::get()
+                .to(|| async { actix_files::NamedFile::open_async("./public/favicon.ico").await }),
         )
-        .wrap(NormalizePath::trim())
-        .inertia_route("/", "index")
-        .inertia_route("/dev/hello/world", "hello-world")
-        .configure(WebRouter::register)
-        .service(actix_files::Files::new("/", "./public/").prefer_utf8(true))
+        .service(
+            web::scope("")
+                .wrap(GarbageCollectorMiddleware)
+                .wrap(get_inertia_middleware())
+                .wrap(ReflashTemporarySessionMiddleware)
+                .wrap(MiddlewareUsuarioDaRequisicao)
+                .wrap(
+                    SessionMiddleware::builder(storage, key)
+                        .cookie_domain(None)
+                        .cookie_http_only(true)
+                        .cookie_same_site(SameSite::Lax)
+                        .cookie_secure(app_config.environment == RustEnv::Production)
+                        .cookie_name(app_config.sessions_cookie_name.to_string())
+                        .build(),
+                )
+                .wrap(NormalizePath::trim())
+                .configure(WebRouter::register)
+                // serviço de fallback de arquivos o ideal é manter tudo fora desse escopo, mas se ainda não tiver
+                // sido montado, esse aqui garante que vai ser entregue mesmo que sofra modificações decorrentes
+                // dos middlewares.
+                .service(actix_files::Files::new("/", "./public/").prefer_utf8(true)),
+        )
 }

--- a/tests/common/utils/headers.rs
+++ b/tests/common/utils/headers.rs
@@ -1,12 +1,10 @@
-use actix_web::body::{BoxBody, EitherBody};
+use actix_web::body::BoxBody;
 use actix_web::cookie::Cookie;
 use actix_web::dev::ServiceResponse;
 use actix_web::http::header;
 use config::app::AppConfig;
 
-pub fn extraia_cookie_da_sessao(
-    response: &ServiceResponse<EitherBody<BoxBody, BoxBody>>,
-) -> Cookie<'_> {
+pub fn extraia_cookie_da_sessao(response: &ServiceResponse<BoxBody>) -> Cookie<'_> {
     response
         .response()
         .cookies()
@@ -14,9 +12,7 @@ pub fn extraia_cookie_da_sessao(
         .expect("Response should contain a session cookie.")
 }
 
-pub fn extraia_valor_do_header_location(
-    response: &ServiceResponse<EitherBody<BoxBody, BoxBody>>,
-) -> &str {
+pub fn extraia_valor_do_header_location(response: &ServiceResponse<BoxBody>) -> &str {
     response
         .headers()
         .get(header::LOCATION)

--- a/tests/controllers/professores/novo_projeto_de_extensao.rs
+++ b/tests/controllers/professores/novo_projeto_de_extensao.rs
@@ -63,7 +63,6 @@ pub async fn um_professor_deveria_poder_criar_um_projeto_de_extensao(
         .await
         .into_assertable_inertia();
 
-    dbg!(&pagina.get_props());
     assert!(pagina.get_props()["errors"].as_object().unwrap().is_empty());
     // endregion: --- Garante que não houve erros
 

--- a/tests/controllers/professores/vagas/criar_vaga_de_projeto.rs
+++ b/tests/controllers/professores/vagas/criar_vaga_de_projeto.rs
@@ -180,7 +180,6 @@ async fn um_professor_deveria_poder_criar_vagas_para_seus_projetos(
         .await
         .into_assertable_inertia();
 
-    dbg!(&page);
     assert!(page.get_props()["errors"].as_object().unwrap().is_empty());
 
     let count: i64 = sqlx::query_scalar("SELECT COUNT(id) FROM vaga")

--- a/www/components/form/editor.tsx
+++ b/www/components/form/editor.tsx
@@ -1,37 +1,48 @@
+import { memo, Suspense, use } from "react";
 import type { TemaEstrito } from "@/tema";
-import { TinyMCEEditor } from "../tinymce-editor";
-import { AlertaDeErro } from "./alerta-de-erro";
+import type { TinyMCEEditorProps } from "../tinymce-editor";
 import { InputLabelSpan } from "./label-span";
+
+// colocar essa promise inline (`use(import("path"))`) faz com que uma nova promise seja
+// gerada a cada renderização, pode ocasionar um loop de re-renderização deste componente.
+const promiseEstavel = import("../tinymce-editor");
+
+const LazyTinyMceEditor = memo((props: TinyMCEEditorProps) => {
+  const { TinyMCEEditor } = use(promiseEstavel);
+  return <TinyMCEEditor {...props} />;
+});
+
+const EditorSkeleton = () => {
+  return (
+    <div className="text-input inert select-none animate-pulse opacity-50 px-3">
+      <span className="block rounded-full bg-black/10 dark:bg-white/10 w-1/4">&nbsp;</span>
+    </div>
+  );
+};
 
 type Props = {
   tema?: TemaEstrito;
   label: string;
   required?: boolean;
   initialValue?: string;
-  value?: string;
-  error?: string;
-  atualizarConteudo: (conteudo: string) => void;
+  erro?: string;
+  atualizarConteudo?: (conteudo: string) => void;
 };
 
-export function Editor({
-  tema = "claro",
-  label,
-  required,
-  error,
-  value,
-  atualizarConteudo,
-  initialValue,
-}: Props) {
-  return (
-    <div className="flex flex-col gap-2">
-      <InputLabelSpan required={required}>{label}</InputLabelSpan>
-      {error && <AlertaDeErro>{error}</AlertaDeErro>}
-      <TinyMCEEditor
-        tema={tema}
-        initialValue={initialValue}
-        value={value}
-        onEditorChange={(html, _editor) => atualizarConteudo(html)}
-      />
-    </div>
-  );
-}
+export const Editor = memo(
+  ({ tema = "claro", label, required, erro, atualizarConteudo, initialValue }: Props) => {
+    return (
+      <div className="flex flex-col gap-2">
+        <InputLabelSpan required={required}>{label}</InputLabelSpan>
+        <Suspense fallback={<EditorSkeleton />}>
+          <LazyTinyMceEditor
+            tema={tema}
+            erro={erro}
+            initialValue={initialValue}
+            onEditorChange={(html, _editor) => atualizarConteudo?.(html)}
+          />
+        </Suspense>
+      </div>
+    );
+  },
+);

--- a/www/components/tinymce-editor.tsx
+++ b/www/components/tinymce-editor.tsx
@@ -53,15 +53,18 @@ import "tinymce/skins/ui/oxide/content.inline.min.css";
 
 import { Editor, type IAllProps } from "@tinymce/tinymce-react";
 import clsx from "clsx";
+import type { RefObject } from "react";
+import type { Editor as TEditor } from "tinymce/tinymce";
 import type { TemaEstrito } from "@/tema";
 import Form from "./form";
 
-type TinyMCEEditorProps = Omit<IAllProps, "licenseKey"> & {
+export type TinyMCEEditorProps = Omit<IAllProps, "licenseKey"> & {
   erro?: string;
   tema: TemaEstrito;
+  editorRef?: RefObject<TEditor>;
 };
 
-export function TinyMCEEditor({ erro, tema, ...props }: TinyMCEEditorProps) {
+export function TinyMCEEditor({ erro, tema, editorRef, ...props }: TinyMCEEditorProps) {
   return (
     <div className="conteudo-editor">
       {erro && <Form.AlertaDeErro>{erro}</Form.AlertaDeErro>}
@@ -101,7 +104,7 @@ export function TinyMCEEditor({ erro, tema, ...props }: TinyMCEEditorProps) {
         ]}
         id="editor"
         init={{
-          skin_url: "default",
+          // skin_url: "default",
           autoresize_bottom_margin: 0,
           language: "pt_BR",
           language_url: "/tiny-mce/langs/pt_BR.js",
@@ -141,6 +144,9 @@ export function TinyMCEEditor({ erro, tema, ...props }: TinyMCEEditorProps) {
           extended_valid_elements: "script[src|async|defer|type|charset],style,div[*],center",
           custom_elements: "style,script,center,div",
           skin: tema === "escuro" ? "oxide-dark" : "oxide",
+          setup: (editor) => {
+            if (editorRef) editorRef.current = editor;
+          },
         }}
       />
     </div>

--- a/www/pages/professores/projetos/novo-projeto-de-extensao.tsx
+++ b/www/pages/professores/projetos/novo-projeto-de-extensao.tsx
@@ -1,6 +1,6 @@
 import { Head, Link, useForm, usePage } from "@inertiajs/react";
 import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
-import type { FormEvent } from "react";
+import type { SubmitEventHandler } from "react";
 import { toast } from "react-toastify";
 import Button from "@/components/button";
 import Form from "@/components/form";
@@ -20,7 +20,7 @@ export default function NovoProjetoDeExtensao() {
   const tema = resolvaTema(props.temaPreferido, props.temaSistema);
   const { post, data, setData, errors, processing } = useForm<FormData>();
 
-  const handleSubmit = (event: FormEvent) => {
+  const handleSubmit: SubmitEventHandler = (event) => {
     event.preventDefault();
 
     post("/professores/projetos/extensao/criar_e_associar", {
@@ -71,11 +71,11 @@ export default function NovoProjetoDeExtensao() {
 
             <Form.Editor
               required
-              label="Conteúdo"
-              error={errors.descricao}
-              atualizarConteudo={(descricao) => setData({ ...data, descricao })}
-              initialValue="Descreva o projeto em detalhes."
               tema={tema}
+              label="Conteúdo"
+              erro={errors.descricao}
+              initialValue="Descreva o projeto em detalhes."
+              atualizarConteudo={(descricao) => setData({ ...data, descricao })}
             />
 
             <div className="flex items-center gap-3 mt-6">

--- a/www/pages/professores/vagas/nova.tsx
+++ b/www/pages/professores/vagas/nova.tsx
@@ -1,5 +1,5 @@
 import { Deferred, Head, useForm, usePage } from "@inertiajs/react";
-import type { FormEvent } from "react";
+import type { SubmitEventHandler } from "react";
 import { toast } from "react-toastify";
 import Button from "@/components/button";
 import Form from "@/components/form";
@@ -41,7 +41,7 @@ export default function CriarNovaVagaDeProjeto() {
     inscricoes_ate: new Date(),
   });
 
-  const handleSubmit = (event: FormEvent) => {
+  const handleSubmit: SubmitEventHandler = (event) => {
     event.preventDefault();
 
     post("/professores/vagas/criar", {
@@ -164,8 +164,8 @@ export default function CriarNovaVagaDeProjeto() {
               tema={tema}
               label="Corpo da vaga"
               atualizarConteudo={(conteudo) => setData({ ...data, conteudo })}
-              error={errors.conteudo}
-              value={data.conteudo}
+              erro={errors.conteudo}
+              initialValue="<p>Descreva a vaga em detalhes.</p>"
               required
             />
 


### PR DESCRIPTION
Esse PR altera os registros de rotas e serviços do servidor actix-web pra evitar que middlewares sejam ativados em requisições de assets nas rotas `/bundle/` e `/ tiny-mce/`. Isso corrige um erro em que o navegador rejeita os scripts e outros assets devido a um header `content-type` inválido setado por algum dos middlewares. Assets em outros caminhos dentro do diretório `/public/` serão resolvidos pelo serviço registrado no final do servidor como um fallback.

Além disso, passa a carregar o editor TinyMCE com lazy_loading + `Suspense` API, o que corrige um novo erro ocasionado pela biblioteca tinymce ao ser importada e outro erro que poderia ocorrer ao tentar ser renderizada pelo servidor.